### PR TITLE
Fix overlay

### DIFF
--- a/frontend/src/app/components/sidebar-widget/sidebar-widget.component.html
+++ b/frontend/src/app/components/sidebar-widget/sidebar-widget.component.html
@@ -60,17 +60,4 @@
       <ng-content></ng-content>
     </div>
   </div>
-  
-  <!-- Overlay -->
-  <div 
-    class="widget-overlay"
-    [class.show]="isOpen"
-    (click)="toggleWidget()"
-    (keydown.enter)="toggleWidget()"
-    (keydown.space)="toggleWidget()"
-    [attr.tabindex]="isOpen ? 0 : -1"
-    role="button"
-    [attr.aria-label]="'Fermer ' + title"
-    (click)="toggleWidget()">
-  </div>
 </div>


### PR DESCRIPTION
Closes #218

Fix a bug, when clicking outside the widget, now close the widget  